### PR TITLE
Fixed README extension in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     url = 'https://launchpad.net/elementflow',
     license = 'LICENSE.txt',
     description = 'Python library for generating XML as a stream without first building a tree in memory.',
-    long_description = open('README.txt').read(),
+    long_description = open('README.md').read(),
 )


### PR DESCRIPTION
Without this fix, the installation of this module is not working.

``` python
long_description = open('README.txt').read(),
IOError: [Errno 2] No such file or directory: 'README.txt'
```
